### PR TITLE
Use original XcodeEditor now that it supports SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.18.0"),
-        .package(url: "https://github.com/lvsti/XcodeEditor.git", .branch("spm-support")),
+        .package(url: "https://github.com/appsquickly/XcodeEditor.git", .branch("master")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Now that https://github.com/appsquickly/XcodeEditor/pull/90 was merged, the SPM can use the original repository since XcodeEditor now that it supports SPM