### PR TITLE
Update SourceKit dependency now that SPM build is fixed

### DIFF
--- a/Bridgecraft/GenerateCommand.swift
+++ b/Bridgecraft/GenerateCommand.swift
@@ -305,7 +305,7 @@ struct GenerateCommand {
                                     arguments: compilerFlags)
         let result: [String: SourceKitRepresentable]
         do {
-            result = try req.failableSend()
+            result = try req.send()
         }
         catch {
             printError("failed to generate interface for \(preprocessedURL.path): \(error)")

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "jpsim/SourceKitten" ~> 0.18.4
+github "jpsim/SourceKitten"
 github "appsquickly/XcodeEditor" "master"
 github "kylef/Commander"

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", .exact("0.18.4")),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", .from("0.19.1")),
         .package(url: "https://github.com/appsquickly/XcodeEditor.git", .branch("master")),
     ],
     targets: [


### PR DESCRIPTION
Now that https://github.com/jpsim/SourceKitten/issues/478 is solved, the SourceKitten dependency can be updated.