### PR TITLE
Add xcode 10 compatibility

### DIFF
--- a/Bridgecraft/GenerateCommand.swift
+++ b/Bridgecraft/GenerateCommand.swift
@@ -204,10 +204,15 @@ struct GenerateCommand {
     }
     
     private func compilerFlagsForBridgingSource() throws -> [String] {
+        
+        // The flag -UseModernBuildSystem=0 is needed because when running xcodebuild with the option -dry-run
+        // It throws the following error
+        // error: -dry-run is not yet supported in the new build system
         var args = [
-            "clean", "build", "-n",
+            "clean", "build", "-dry-run",
             "-project", tempProjectURL.path,
-            "-target", targetName
+            "-target", targetName,
+            "-UseModernBuildSystem=0" // TODO: remove -UseModernBuildSystem=0 once the new build system supports -dry-run
         ]
         
         if let sdk = sdkOverride {

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "jpsim/SourceKitten"
+github "jpsim/SourceKitten" ~> 0.21.2
 github "appsquickly/XcodeEditor" "master"
-github "kylef/Commander"
+github "kylef/Commander" ~> 0.8.0

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.20.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.2"),
         .package(url: "https://github.com/appsquickly/XcodeEditor.git", .branch("master")),
     ],
     targets: [


### PR DESCRIPTION
Hello, Bridgecraft is not working with Xcode 10, so here is a PR to make it compatible.

Basically the problem is that the new build system, the default one in Xcode 10, doesn't support `-dry-run` yet, so in order to Bridgecraft to work, it must explicitly use the legacy build system.

Once the new build system supports `-dry-run`, the flag `-UseModernBuildSystem=0` can be removed.

I also replaced `-n` with `-dry-run`, because the error that was outputted was `error: -dry-run is not yet supported in the new build system`, but I couldn't find that option anywhere, until after a lot of trial error, I discovered that `-n` and `-dry-run` are the same, maybe `-n` it's just the abbreviation, so I made it explicitly.

I added pin versions to Carthage, to make sure that Carthage and Swift Package Manager dependencies versions match.

NOTE: This is not related itself with the PR, but there are some dependencies that are not it compatible with Swift 4.2, and Xcode 10 can't build Bridgecraft, so in order to create the next release, you will need to use Xcode 9. This also applies when updating Carthage.

If you have any question please let me know.