### PR TITLE
Improve error messages

### DIFF
--- a/Bridgecraft/GenerateCommand.swift
+++ b/Bridgecraft/GenerateCommand.swift
@@ -11,13 +11,15 @@ import SourceKittenFramework
 import XcodeEdit
 
 extension GenerateCommand {
-    static func execute(assumeNonnull: Bool,
+    static func execute(verbose: Bool,
+                        assumeNonnull: Bool,
                         sdkOverride: [String],
                         destOverride: [String],
                         outputPath: [String],
                         origProjectPath: String,
                         targetName: String) {
-        let cmd = GenerateCommand(assumeNonnull: assumeNonnull,
+        let cmd = GenerateCommand(verbose: verbose,
+                                  assumeNonnull: assumeNonnull,
                                   sdkOverride: sdkOverride,
                                   destOverride: destOverride,
                                   outputPath: outputPath,
@@ -34,17 +36,20 @@ struct GenerateCommand {
     private let preprocessedURL: URL
     private let outputFileURL: URL?
     
+    private let verbose: Bool
     private let assumeNonnull: Bool
     private let sdkOverride: String?
     private let destOverride: String?
     private let targetName: String
     
-    init(assumeNonnull: Bool,
+    init(verbose: Bool,
+         assumeNonnull: Bool,
          sdkOverride: [String],
          destOverride: [String],
          outputPath: [String],
          origProjectPath: String,
          targetName: String) {
+        self.verbose = verbose
         self.assumeNonnull = assumeNonnull
         self.sdkOverride = sdkOverride.first
         self.destOverride = destOverride.first
@@ -130,7 +135,7 @@ struct GenerateCommand {
                 "-showBuildSettings",
                 "-project", tempProjectURL.path,
                 "-target", targetName
-            ])
+            ], verbose: verbose)
         }
         catch {
             printError("cannot query build settings for \(tempProjectURL.path): \(error)")
@@ -245,7 +250,7 @@ struct GenerateCommand {
         
         let output: String
         do {
-            output = try shell("/usr/bin/xcodebuild", args: args)
+            output = try shell("/usr/bin/xcodebuild", args: args, verbose: verbose)
         }
         catch {
             printError("cannot dry-run build for \(tempProjectURL.path)")
@@ -298,7 +303,7 @@ struct GenerateCommand {
                 "-x", "objective-c", "-C", "-fmodules", "-fimplicit-modules",
                 "-E", bridgingSourceURL.path,
                 "-o", preprocessedURL.path
-                ] + compilerFlags)
+                ] + compilerFlags, verbose: verbose)
         }
         catch {
             printError("failed to preprocess file at \(bridgingSourceURL.path): \(error)")

--- a/Bridgecraft/Utils.swift
+++ b/Bridgecraft/Utils.swift
@@ -13,7 +13,12 @@ enum BridgecraftError: Error {
 }
 
 @discardableResult
-func shell(_ command: String, args: [String]) throws -> String {
+func shell(_ command: String, args: [String], verbose: Bool = false) throws -> String {
+    
+    if verbose {
+        print("\(command) \(args.joined(separator: " "))")
+    }
+    
     let ps = Process()
     ps.launchPath = command
     ps.arguments = args

--- a/Bridgecraft/Utils.swift
+++ b/Bridgecraft/Utils.swift
@@ -26,10 +26,13 @@ func shell(_ command: String, args: [String], verbose: Bool = false) throws -> S
     
     ps.launch()
     
-    ps.waitUntilExit()
-    
-    let outputPipeResult = outputPipe.fileHandleForReading.readDataToEndOfFile()
-    let errorPipeResult = errorPipe.fileHandleForReading.readDataToEndOfFile()
+    var outputPipeResult = Data()
+    var errorPipeResult = Data()
+
+    while ps.isRunning {
+        outputPipeResult.append(outputPipe.fileHandleForReading.readDataToEndOfFile())
+        errorPipeResult.append(errorPipe.fileHandleForReading.readDataToEndOfFile())
+    }
     
     guard
         let output = String(data: outputPipeResult, encoding: String.Encoding.utf8),

--- a/Bridgecraft/Utils.swift
+++ b/Bridgecraft/Utils.swift
@@ -21,6 +21,10 @@ func shell(_ command: String, args: [String], verbose: Bool = false) throws -> S
     
     let pipe = Pipe()
     ps.standardOutput = pipe
+    // We associate a dummy Pipe to the Process.standardError
+    // to prevent the Process from printing the short error description to the terminal
+    // since now we are printing the full error description
+    ps.standardError = Pipe()
     
     ps.launch()
     

--- a/Bridgecraft/Utils.swift
+++ b/Bridgecraft/Utils.swift
@@ -54,7 +54,7 @@ func shell(_ command: String, args: [String], verbose: Bool = false) throws -> S
     if verbose {
         print("\(command) \(args.joined(separator: " "))")
         print(output)
-        print(error)
+        printError(error)
     }
     
     return output

--- a/Bridgecraft/Utils.swift
+++ b/Bridgecraft/Utils.swift
@@ -31,11 +31,13 @@ func shell(_ command: String, args: [String], verbose: Bool = false) throws -> S
     let outputPipeResult = outputPipe.fileHandleForReading.readDataToEndOfFile()
     let errorPipeResult = errorPipe.fileHandleForReading.readDataToEndOfFile()
     
-    guard let output = String(data: outputPipeResult, encoding: String.Encoding.utf8),
-    let error = String(data: errorPipeResult, encoding: String.Encoding.utf8) else {
-        printError("\(command) \(args.joined(separator: " "))")
-        printError("Error parsing the output of the previous command.")
-        throw BridgecraftError.unknown
+    guard
+        let output = String(data: outputPipeResult, encoding: String.Encoding.utf8),
+        let error = String(data: errorPipeResult, encoding: String.Encoding.utf8)
+        else {
+            printError("\(command) \(args.joined(separator: " "))")
+            printError("Error parsing the output of the previous command.")
+            throw BridgecraftError.unknown
     }
     
     guard ps.terminationStatus == 0 else {

--- a/Bridgecraft/main.swift
+++ b/Bridgecraft/main.swift
@@ -12,6 +12,7 @@ import Foundation
 let version = "0.3.0"
 
 let generate = command(
+    Flag("verbose", description: "output's all terminal commands and their results"),
     Flag("assume-nonnull", description: "assume that all headers have been audited for nullability"),
     Options<String>("sdk", default: [], count: 1, description: "override the SDK used for the build (see xcodebuild -sdk)"),
     Options<String>("destination", default: [], count: 1, description: "override the destination device used for the build (see xcodebuild -destination)"),


### PR DESCRIPTION
Hello, this PR fixes https://github.com/lvsti/Bridgecraft/issues/20.

It show's more explicit errors and add a verbose flag that prints all shell commands and the respective responses.

Here is an example of how the error are showed now:
```
/usr/bin/xcodebuild clean build -dry-run -project XcodeProject.xcodeproj -target XcodeProjectTarget -UseModernBuildSystem=0 -sdk iphonesimulator -destination platform=iOS Simulator,name=iPhone X,OS=latest
Terminated with the status 65.
User defaults from command line:
    UseModernBuildSystem = 0

Build settings from command line:
    SDKROOT = iphonesimulator12.0

Prepare build
note: Using legacy build system

=== CLEAN TARGET XcodeProjectTarget OF PROJECT XcodeProjectTarget WITH THE DEFAULT CONFIGURATION (Debug) ===

Check dependencies
[BEROR]No architectures to compile for (ONLY_ACTIVE_ARCH=YES, active arch=i386, VALID_ARCHS=arm64 armv7s).

Create product structure
/bin/mkdir -p /Users/User/Developer/XcodeProject/build/Debug-iphonesimulator/XcodeProjectTarget.app

Clean.Remove clean build/XcodeProjectTarget.build/Debug-iphonesimulator/XcodeProjectTarget.build
    builtin-rm -rf /Users/User/Developer/XcodeProject/build/XcodeProjectTarget.build/Debug-iphonesimulator/XcodeProjectTarget.build

Clean.Remove clean build/Debug-iphonesimulator/XcodeProjectTarget.app
    builtin-rm -rf /Users/User/Developer/XcodeProject/build/Debug-iphonesimulator/XcodeProjectTarget.app

** CLEAN SUCCEEDED **

Prepare build
note: Using legacy build system

=== BUILD TARGET XcodeProjectTarget OF PROJECT XcodeProjectTarget WITH THE DEFAULT CONFIGURATION (Debug) ===

Check dependencies
No architectures to compile for (ONLY_ACTIVE_ARCH=YES, active arch=i386, VALID_ARCHS=arm64 armv7s).


** BUILD FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
```