### PR TITLE
Migrate Commander to version 0.9.0

### DIFF
--- a/Bridgecraft/main.swift
+++ b/Bridgecraft/main.swift
@@ -18,7 +18,7 @@ let generate = command(
     Options<String>("output", default: [], flag: "o", count: 1, description: "write the generated interface into the given file instead of the standard output"),
     Argument<String>("project", description: "path to the project file"),
     Argument<String>("target", description: "name of the target to use"),
-    VariadicArgument<String>("xcflags", description: "additional parameters to pass to xcodebuild"),
+    Argument<[String]>("xcflags", description: "additional parameters to pass to xcodebuild"),
     GenerateCommand.execute
 )
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "jpsim/SourceKitten" ~> 0.21.2
-github "lvsti/Commander" "bare-double-dash"
+github "kylef/Commander" ~> 0.9.0
 github "tomlokhorst/XcodeEdit" ~> 2.4.2

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .executable(name: "bridgecraft", targets: ["Bridgecraft"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/lvsti/Commander.git", .branch("bare-double-dash")),
+        .package(url: "https://github.com/kylef/Commander.git", from: "0.9.0"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.2"),
         .package(url: "https://github.com/tomlokhorst/XcodeEdit.git", from: "2.4.2"),
     ],


### PR DESCRIPTION
Hey,
https://github.com/kylef/Commander/pull/75 just got merged and released in the version 0.9.0.
So this PR uses that version.
